### PR TITLE
imps support flake8-import-order 0.11

### DIFF
--- a/imps/core.py
+++ b/imps/core.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, division, print_function
 
 import re
 
-from imps.rebuilders import does_line_end_in_noqa, Rebuilder
+from imps.rebuilders import does_line_end_in_noqa, Rebuilder, sortable_key
 
 from imps.strings import get_doc_string
 
@@ -15,14 +15,14 @@ FROM_IMPORT_LINE_WITH_PARAN = r'^from\s.*import\s.*\('
 def sort_from_import(s):
     from_part, import_list = re.split('\s+import\s+', s, 1)
     imps = import_list.split(',')
-    imps = sorted(set([i.strip() for i in imps if i.strip()]), key=lambda s: s.lower())
+    imps = sorted(set([i.strip() for i in imps if i.strip()]), key=sortable_key)
     return from_part + " import " + ', '.join(imps)
 
 
 def split_imports(s):
     _, import_list = re.split('^import\s+', s, 1)
     imps = import_list.split(',')
-    imps = sorted(set([i.strip() for i in imps if i.strip()]), key=lambda s: s.lower())
+    imps = sorted(set([i.strip() for i in imps if i.strip()]), key=sortable_key)
     return "import " + ', '.join(imps)
 
 

--- a/imps/rebuilders.py
+++ b/imps/rebuilders.py
@@ -11,6 +11,21 @@ FROM_IMPORT_LINE = r'^from\s.*import\s.*'
 FROM_IMPORT_PARAN_LINE = r'^from\s.*import\s\(.*'
 
 
+def sortable_key(s):
+    s = s.strip()
+    broken_s = s.split(' ')
+    results = []
+    for bs in broken_s:
+        new_s = ''
+        for c in bs:
+            if c.islower():
+                new_s += '1'
+            else:
+                new_s += '0'
+        results.append(bs.lower() + new_s)
+    return ' '.join(results)
+
+
 def does_line_end_in_noqa(line):
     return re.match(NOQA, line, re.IGNORECASE)
 
@@ -44,16 +59,14 @@ def sorter_relative_imports(s):
 def sorter(s):
     s = s.replace('.', chr(ord('A') - 2))
     s = s.replace('_', chr(ord('A') - 1))
-    s = s.lower()
     # We only alphabetically sort the from part of the imports in style: from X import Y
     if re.match(FROM_IMPORT_PARAN_LINE, s):
         s = re.sub('\#.*\n', '', s)
         s = re.sub('\s+', ' ', s)
-        s = s[0:s.find(' import ')].lower() + ' import' + s[s.find('(') + 1:s.find(')')]
-        return s.strip()
+        s = sortable_key(s[4:s.find(' import ')]) + ' import' + s[s.find('(') + 1:s.find(')')]
     if re.match(FROM_IMPORT_LINE, s):
-        return (s[0:s.find(' import ')].lower() + s[s.find(' import '):]).strip()
-    return s
+        s = sortable_key(s[4:s.find(' import ')]) + s[s.find(' import '):]
+    return sortable_key(s)
 
 
 def sorter_unify_import_and_from(s):

--- a/imps/tests/test_core.py
+++ b/imps/tests/test_core.py
@@ -382,3 +382,18 @@ def test_split_from_import_with_as():
 def test_split_from_import_with_import_in_comment():
     test = sort_from_import('from os.path import abspath, dirname, join  # noqa # import order')
     assert test
+
+
+def test_order_withcapitals():
+    """ flake8_import_order v 0.11 behaviour changed slightly to handle capital letters more strictly"""
+    input = '''import b
+import B
+
+from pytest import a, A
+'''
+    correct = '''import B
+import b
+
+from pytest import A, a
+'''
+    assert Sorter().sort(input) == correct

--- a/imps/tests/test_rebuilders.py
+++ b/imps/tests/test_rebuilders.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, division, print_function
 
-from imps.rebuilders import Rebuilder, sorter
+from imps.rebuilders import Rebuilder
 
 
 def test_split_core_import():
@@ -19,14 +19,3 @@ def test_split_core_import_noqa():
     s = Rebuilder(max_line_length=40)
     input = "import alpha.alpha.alpha, beta.beta.beta, gamma.gamma.gamma  # NOQA"
     assert s.split_core_import(input) == input
-
-
-def test_sorter():
-    assert sorter("""from a import B, C""") == 'from a import b, c'
-
-
-def test_sorter_with_complex_from_import():
-    assert sorter("""from a import ( # hello
-    B, # hi
-    C
-)""") == 'from a import b, c'

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='imps',
-    version='0.2.1',
+    version='0.2.2',
     description='Python utility to sort Python imports',
     author='Andy Boot',
     url='https://github.com/bootandy/imps',


### PR DESCRIPTION
This version sorts
import x
import X
to:
import X
import x

as required by the newest version of flake8-import-order